### PR TITLE
Prevent events from swapping lanes

### DIFF
--- a/src/components/EventList.tsx
+++ b/src/components/EventList.tsx
@@ -1,37 +1,36 @@
-import { useState, useEffect } from 'react';
-import { EventItem } from './EventItem';
-import { allEvents } from '../data/allEvents';
-import moment from 'moment';
+import { useState, useEffect, useRef } from "react";
+import { EventItem } from "./EventItem";
+import { allEvents } from "../data/allEvents";
+import moment from "moment";
 
 interface Event {
   title: string;
   description: string;
   time: string;
+  isLeft: boolean;
 }
 
 export function EventList() {
-  let now = moment().format();
+  const now = useRef(moment().format());
   const [upcomingEvents, setUpcomingEvents] = useState<Event[]>([]);
 
+  const isLeftRef = useRef(false);
+
   useEffect(() => {
-    eventSetter();
-  }, []);
-
-  function eventSetter() {
     setInterval(function () {
-      setUpcomingEvents((upcomingEvents) => [
-        newEventGenerator(),
-        ...upcomingEvents.slice(0, 4),
-      ]);
+      const isLeft = isLeftRef.current;
+      isLeftRef.current = !isLeft;
+      setUpcomingEvents((events) => {
+        const newEvent = {
+          ...allEvents[Math.floor(Math.random() * 9)],
+          isLeft,
+          time: now.current,
+        };
+        return [newEvent, ...events.slice(0, 4)];
+      });
+      now.current = moment(now.current).add(57, "minutes").format();
     }, 5000);
-  }
-
-  function newEventGenerator() {
-    const newEvent = { ...allEvents[Math.floor(Math.random() * 9)] };
-    now = moment(now).add(57, 'minutes').format();
-    newEvent.time = now;
-    return newEvent;
-  }
+  }, []);
 
   return (
     <div>
@@ -42,7 +41,12 @@ export function EventList() {
         <div className={styles.eventsContainer}>
           {upcomingEvents.map((event) => {
             return (
-              <div key={event.time} className={styles.eventItem}>
+              <div
+                key={event.time}
+                className={`${styles.eventItem} ${
+                  event.isLeft ? styles.left : styles.right
+                }`}
+              >
                 <EventItem
                   title={event.title}
                   description={event.description}
@@ -58,11 +62,12 @@ export function EventList() {
 }
 
 const styles = {
-  container: 'max-w-2xl min-w-sm relative',
-  header: 'text-2xl sm:text-4xl font-bold text-pink-900 pb-6',
-  eventsContainer: 'items-center justify-center m-auto',
-  mobileTimeline: 'absolute w-1 h-screen bg-pink-200 sm:bg-transparent ml-1 ',
-  desktopTimeline: 'absolute w-1 h-screen sm:bg-gray-200 left-1/2',
-  eventItem:
-    'first:animate-bounce sm:odd:float-left sm:clear-both sm:even:float-right ml-2 mr-2',
+  container: "max-w-2xl min-w-sm relative",
+  header: "text-2xl sm:text-4xl font-bold text-pink-900 pb-6",
+  eventsContainer: "items-center justify-center m-auto",
+  mobileTimeline: "absolute w-1 h-screen bg-pink-200 sm:bg-transparent ml-1 ",
+  desktopTimeline: "absolute w-1 h-screen sm:bg-gray-200 left-1/2",
+  eventItem: "first:animate-bounce sm:clear-both ml-2 mr-2",
+  left: "sm:float-left",
+  right: "sm:float-right",
 };


### PR DESCRIPTION
Hi Mary, from what I could tell after recreating what we had done during the pairing exercise, reference changes don't play well with React's set action callbacks (The callback function inside of `setUpcomingEvents`). It was as simple as setting the ref one layer above, at the `setInterval`'s callback layer.

Sorry that I didn't spot that during the interview, I should have noticed that earlier. Here's the the solution, if you want to take a look at it.

You'll be hearing from Anisa soon :)